### PR TITLE
Relax dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.3.0
-termcolor==1.1.0
+requests>=2.3.0,<3.0
+termcolor>=1.1.0,<2.0

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ setup(
     maintainer='Dan OBrien',
     maintainer_email='danob@jana.com',
     install_requires=[
-        'requests==2.3.0',
-        'termcolor==1.1.0'
+        'requests>=2.3.0,<3.0',
+        'termcolor>=1.1.0,<2.0'
     ],
     license='LICENSE.txt',
     packages=['onesky'],


### PR DESCRIPTION
Having strict dependency versions makes it hard to use onesky-python in a larger project with lots of dependencies.

Requests uses semantic versioning, so onesky-python should theoretically not hit any compatibility issues with anything up to but not including their 3.0 release (which doesn't exist yet).

termcolor doesn't seem to change, but opening it up assuming semantic versioning too.
